### PR TITLE
meross info: add 'from' to request header

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -209,6 +209,7 @@ module.exports = class API {
     async deviceWifiList() {
         const packet = this.signPacket({
             'header':   {
+                'from': '',
                 'method': 'GET',
                 'namespace': 'Appliance.Config.WifiList'
             },
@@ -302,6 +303,7 @@ module.exports = class API {
 
         const packet = this.signPacket({
             'header':   {
+                'from': '',
                 'method': 'SET',
                 'namespace': 'Appliance.Config.Key'
             },
@@ -346,6 +348,7 @@ module.exports = class API {
 
         const packet = this.signPacket({
             'header':   {
+                'from': '',
                 'method': 'SET',
                 'namespace': 'Appliance.Config.Wifi'
             },

--- a/lib/api.js
+++ b/lib/api.js
@@ -142,6 +142,7 @@ module.exports = class API {
     async deviceInformation() {
         const packet = this.signPacket({
             'header':   {
+                'from': '',
                 'method': 'GET',
                 'namespace': 'Appliance.System.All'
             },


### PR DESCRIPTION
In my environment, (mss110 un rtl8710cm (hardware:7.0.0 firmware:7.2.3))
`./meross info` will fail with
```
Error Unable to connect to device
```
According to https://github.com/albertogeniola/MerossIot/wiki/Device-pairing#configuration-phase , `'from'` field is maybe needed at the header of request of getting device info.

**Log 1: Before Modification of this PR**
```
$ ./bin/meross info
Getting info about device with IP 10.10.10.1
Error Unable to connect to device
```

**Log 2: Before Modification of this PR, with -v (Occuring Issue #35)**
```
$ ./bin/meross info -v
Getting info about device with IP 10.10.10.1
> POST /config
> Host: 10.10.10.1
> Accept: application/json, text/plain, */*
> Content-Type: application/json
>
{
  header: {
    method: 'GET',
    namespace: 'Appliance.System.All',
    messageId: '03c122a4bd4a623e8bc1e81f789269a7',
    timestamp: 1629752366,
    sign: '0a57f44d3aa131ba2f161b60cefd9766'
  },
  payload: {}
}

node:internal/process/promises:227
          triggerUncaughtException(err, true /* fromPromise */);
          ^

TypeError [ERR_INVALID_ARG_TYPE]: The "url" argument must be of type string. Received undefined
    at new NodeError (node:internal/errors:329:5)
    at validateString (node:internal/validators:129:11)
    at Url.parse (node:url:169:3)
    at Object.urlParse [as parse] (node:url:156:13)
    at new URL (/home/pi/Downloads/Meross/lib/api.js:6:35)
    at logRequest (/home/pi/Downloads/Meross/lib/api.js:62:15)
    at handleRequestError (/home/pi/Downloads/Meross/lib/api.js:99:13)
    at API.deviceInformation (/home/pi/Downloads/Meross/lib/api.js:205:13)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async /home/pi/Downloads/Meross/bin/meross-info:42:5 {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

**Log 3: Before Modification of this PR, with -v (Workaround of Issue #35 Applied)**
```
$ ./bin/meross info -v
Getting info about device with IP 10.10.10.1
> POST /config
> Host: 10.10.10.1
> Accept: application/json, text/plain, */*
> Content-Type: application/json
>
{
  header: {
    method: 'GET',
    namespace: 'Appliance.System.All',
    messageId: '4db25ab10a7277c0df4fddbfb439ab4c',
    timestamp: 1629752556,
    sign: 'b502bce548201b887d8a36c984fc9423'
  },
  payload: {}
}

Error socket hang up
```

**Log 4: After Modification of this PR (Workaround of Issue #35 Applied)**
```
$ ./bin/meross info -v
Getting info about device with IP 10.10.10.1
┌─────────────┬───────────────────────────────────────────────────────────────────────────────┐
│Device       │mss110 un rtl8710cm (hardware:7.0.0 firmware:7.2.3)                            │
├─────────────┼───────────────────────────────────────────────────────────────────────────────┤
│UUID         │xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                               │
├─────────────┼───────────────────────────────────────────────────────────────────────────────┤
│Mac address  │48:e1:e9:xx:xx:xx                                                              │
├─────────────┼───────────────────────────────────────────────────────────────────────────────┤
│IP address   │10.10.10.1                                                                     │
├─────────────┼───────────────────────────────────────────────────────────────────────────────┤
│Credentials  │User: 48:e1:e9:xx:xx:xx                                                        │
│             │Password: 0_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx                                   │
├─────────────┼───────────────────────────────────────────────────────────────────────────────┤
│MQTT topics  │Publishes to: /appliance/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/publish              │
│             │Subscribes to: /appliance/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/subscribe           │
└─────────────┴───────────────────────────────────────────────────────────────────────────────┘
```

**Log 5: Test with curl : without 'from' field**
```
$ curl -X POST -H "Content-Type: application/json" -d '{"header":{"messageId":"","method":"GET","namespace":"Appliance.System.All","payloadVersion":0,"sign":"","timestamp":0},"payload":{}}' 10.10.10.1/config
curl: (52) Empty reply from server
```
**Log 6: Test with curl : with 'from' field**
```
$ curl -X POST -H "Content-Type: application/json" -d '{"header":{"from":"","messageId":"","method":"GET","namespace":"Appliance.System.All","payloadVersion":0,"sign":"","timestamp":0},"payload":{}}' 10.10.10.1/config
{"header":{"messageId":"","namespace":"Appliance.System.All","method":"GETACK","payloadVersion":1,"from":"/appliance/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/publish","uuid":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","timestamp":11868,"timestampMs":327,"sign":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"},"payload":{"all":{"system":{"hardware":{"type":"mss110","subType":"un","version":"7.0.0","chipType":"rtl8710cm","uuid":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","macAddress":"48:e1:e9:xx:xx:xx"},"firmware":{"version":"7.2.3","homekitVersion":"4.1","compileTime":"2021/04/27-17:46:00","encrypt":1,"wifiMac":"","innerIp":"10.10.10.1","server":"","port":0,"userId":0},"time":{"timestamp":11868,"timezone":"","timeRule":[]},"online":{"status":2,"bindId":"","who":0}},"digest":{"togglex":[{"channel":0,"onoff":0,"lmTime":0}],"triggerx":[],"timerx":[]}}}}
```

