### PR TITLE
Support encrypted wifi password on Appliance.Config.WifiX namespace

### DIFF
--- a/bin/meross-setup
+++ b/bin/meross-setup
@@ -35,6 +35,7 @@ program
   .option('-g, --gateway <gateway>', 'Set the gateway address', '10.10.10.1')
   .option('--wifi-ssid <wifi-ssid>', 'WIFI AP name')
   .option('--wifi-pass <wifi-pass>', 'WIFI AP password')
+  .option('--use-wifi-x', 'Use newer protocol on WifiX namespace with encrypted password')
   .option('--wifi-encryption <wifi-encryption>', 'WIFI AP encryption(this can be found using meross info --include-wifi)', parseIntWithValidation)
   .option('--wifi-cipher <wifi-cipher>', 'WIFI AP cipher (this can be found using meross info --include-wifi)', parseIntWithValidation)
   .option('--wifi-bssid <wifi-bssid>', 'WIFI AP BSSID (each octet seperated by a colon `:`)')
@@ -98,6 +99,6 @@ if (undefined !== options.wifiCipher && isNaN(options.wifiCipher)) {
         encryption: options.wifiEncryption,
         cipher: options.wifiCipher,
         bssid: options.wifiBssid,
-    })
+    }, options.useWifiX)
     console.log(`Device will reboot...`)
 })()

--- a/lib/api.js
+++ b/lib/api.js
@@ -13,6 +13,7 @@ const uuid4 = require('uuid4')
 const md5 = require('md5')
 const term = require( 'terminal-kit' ).terminal
 const axios = require('axios')
+const crypto = require('crypto')
 
 const cleanServerUrl = (server) => {
     server = /mqtts?:\/\//.test(server) ? server : 'mqtt://' + server // add protocol
@@ -174,36 +175,42 @@ module.exports = class API {
                 return
             }
 
-            const system = data.payload.all.system
-            const digest = data.payload.all.digest
-            const hw = system.hardware
-            const fw = system.firmware
-
-            let rows = [
-                ['Device', `${hw.type} ${hw.subType} ${hw.chipType} (hardware:${hw.version} firmware:${fw.version})`],
-                ['UUID', hw.uuid],
-                ['Mac address', hw.macAddress],
-                ['IP address', fw.innerIp],
-            ];
-
-            if (fw.server) {
-                rows.push(
-                    ['Current MQTT broker', `${fw.server}:${fw.port}`]
-                )
-            }
-
-            rows.push(
-                ['Credentials', `User: ^C${hw.macAddress}\nPassword: ^C${this.calculateDevicePassword(hw.macAddress, fw.userId)}`],
-                ['MQTT topics', `Publishes to: ^C/appliance/${hw.uuid}/publish\nSubscribes to: ^C/appliance/${hw.uuid}/subscribe`]
-            )
-
-            term.table(
-                rows,
-                tableOptions
-            )
+            return data.payload.all
         } catch (error) {
             handleRequestError(error, this.verbose)
         }
+    }
+
+    async printDeviceInformation() {
+        const data = await this.deviceInformation()
+
+        const system = data.system
+        const digest = data.digest
+        const hw = system.hardware
+        const fw = system.firmware
+
+        let rows = [
+            ['Device', `${hw.type} ${hw.subType} ${hw.chipType} (hardware:${hw.version} firmware:${fw.version})`],
+            ['UUID', hw.uuid],
+            ['Mac address', hw.macAddress],
+            ['IP address', fw.innerIp],
+        ];
+
+        if (fw.server) {
+            rows.push(
+                ['Current MQTT broker', `${fw.server}:${fw.port}`]
+            )
+        }
+
+        rows.push(
+            ['Credentials', `User: ^C${hw.macAddress}\nPassword: ^C${this.calculateDevicePassword(hw.macAddress, fw.userId)}`],
+            ['MQTT topics', `Publishes to: ^C/appliance/${hw.uuid}/publish\nSubscribes to: ^C/appliance/${hw.uuid}/subscribe`]
+        )
+
+        term.table(
+            rows,
+            tableOptions
+        )
     }
 
     async deviceWifiList() {
@@ -342,15 +349,16 @@ module.exports = class API {
         }
     }
 
-    async configureWifiCredentials(credentials) {
+    async configureWifiCredentials(credentials, useWifiX = null) {
         const ssid = base64Encode(credentials.ssid)
-        const password = base64Encode(credentials.password)
+        const namespace = useWifiX ? 'Appliance.Config.WifiX' : 'Appliance.Config.Wifi'
+        const password = useWifiX ? await this.encryptPassword(credentials.password) : base64Encode(credentials.password)
 
         const packet = this.signPacket({
             'header':   {
                 'from': '',
                 'method': 'SET',
-                'namespace': 'Appliance.Config.Wifi'
+                'namespace': namespace
             },
             'payload': {
                 'wifi': {
@@ -376,7 +384,30 @@ module.exports = class API {
         }
     }
 
+    async encryptPassword(password) {
+        const data = await this.deviceInformation();
+
+        return this.calculateWifiXPassword(password, 
+            data.system.hardware.type, 
+            data.system.hardware.uuid, 
+            data.system.hardware.macAddress)
+    }
+
     calculateDevicePassword(macAddress, user = null) {
         return `${user}_${md5(macAddress + '' + this.key)}`
+    }
+
+    calculateWifiXPassword(password, type, uuid, macAddress) {
+        const key = Buffer.from(md5(type+uuid+macAddress).toString('hex'), 'utf8')
+        const iv = Buffer.from('0000000000000000', 'utf8')
+        const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+
+        const count = Math.ceil(password.length/16)*16;
+        const padded = password.padEnd(count, '\0')
+
+        let encrypted = cipher.update(padded, 'utf8', 'base64');
+        encrypted += cipher.final('base64')
+
+        return encrypted
     }
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -141,6 +141,38 @@ module.exports = class API {
     }
 
     async deviceInformation() {
+        const data = await this.deviceInformationData()
+
+        const system = data.system
+        const digest = data.digest
+        const hw = system.hardware
+        const fw = system.firmware
+
+        let rows = [
+            ['Device', `${hw.type} ${hw.subType} ${hw.chipType} (hardware:${hw.version} firmware:${fw.version})`],
+            ['UUID', hw.uuid],
+            ['Mac address', hw.macAddress],
+            ['IP address', fw.innerIp],
+        ];
+
+        if (fw.server) {
+            rows.push(
+                ['Current MQTT broker', `${fw.server}:${fw.port}`]
+            )
+        }
+
+        rows.push(
+            ['Credentials', `User: ^C${hw.macAddress}\nPassword: ^C${this.calculateDevicePassword(hw.macAddress, fw.userId)}`],
+            ['MQTT topics', `Publishes to: ^C/appliance/${hw.uuid}/publish\nSubscribes to: ^C/appliance/${hw.uuid}/subscribe`]
+        )
+
+        term.table(
+            rows,
+            tableOptions
+        )
+    }
+
+    async deviceInformationData() {
         const packet = this.signPacket({
             'header':   {
                 'from': '',
@@ -179,38 +211,6 @@ module.exports = class API {
         } catch (error) {
             handleRequestError(error, this.verbose)
         }
-    }
-
-    async printDeviceInformation() {
-        const data = await this.deviceInformation()
-
-        const system = data.system
-        const digest = data.digest
-        const hw = system.hardware
-        const fw = system.firmware
-
-        let rows = [
-            ['Device', `${hw.type} ${hw.subType} ${hw.chipType} (hardware:${hw.version} firmware:${fw.version})`],
-            ['UUID', hw.uuid],
-            ['Mac address', hw.macAddress],
-            ['IP address', fw.innerIp],
-        ];
-
-        if (fw.server) {
-            rows.push(
-                ['Current MQTT broker', `${fw.server}:${fw.port}`]
-            )
-        }
-
-        rows.push(
-            ['Credentials', `User: ^C${hw.macAddress}\nPassword: ^C${this.calculateDevicePassword(hw.macAddress, fw.userId)}`],
-            ['MQTT topics', `Publishes to: ^C/appliance/${hw.uuid}/publish\nSubscribes to: ^C/appliance/${hw.uuid}/subscribe`]
-        )
-
-        term.table(
-            rows,
-            tableOptions
-        )
     }
 
     async deviceWifiList() {
@@ -385,7 +385,7 @@ module.exports = class API {
     }
 
     async encryptPassword(password) {
-        const data = await this.deviceInformation();
+        const data = await this.deviceInformationData();
 
         return this.calculateWifiXPassword(password, 
             data.system.hardware.type, 


### PR DESCRIPTION
Support for Wifi configuration on the _Appliance.Config.WifiX_ namespace which needs an encrypted password. 

Adds `--use-wifi-x` commandline argument.

Once more thoroughly testet, we might think about using the _Appliance.Config.WifiX_ way per default to make it harder to snoop the actual wifi password by someone listening in on that unsecured access point dataframes.

Successfully tested on a _mss310eu_ plug version 6, firmware version 6.1.12
```
hardware: {
          type: 'mss310',
          subType: 'un',
          version: '6.0.0',
          chipType: 'rtl8710cf',
          uuid: 'XXXXXXXXXXXXXXXXXXXXXXXXXXX',
          macAddress: 'XX:XX:XX:XX:XX'
        },
        firmware: {
          version: '6.1.12',
          compileTime: '2022/05/26-15:39:26',
          encrypt: 1,
          wifiMac: '',
          innerIp: '10.10.10.1',
          server: 'X.X.X.X',
          port: 8883,
          userId: 0
        }
```

Feedback or pull appreciated