### PR TITLE
Remove async from signature method

### DIFF
--- a/packages/lib/src/message/message.ts
+++ b/packages/lib/src/message/message.ts
@@ -19,7 +19,7 @@ export class Message {
    *
    * @param {string} key
    */
-  async sign(key = '') {
+  sign(key = '') {
     const { messageId, timestamp } = this.header;
     this.header.sign = md5(`${messageId}${key}${timestamp}`, 'hex');
   }


### PR DESCRIPTION
`Transport.send()` was calling an async method `Message.sign()` without await. Since the sign method is synchronous, async has been removed from the method signature.